### PR TITLE
To V2 (due to breaking change by 7.0)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,8 +6,8 @@ on:
       tagName:
         description: "Tag name"
         required: true
-        default: 'v1'
-        
+        default: 'v2'
+
 jobs:
   push_to_registry:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3 
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 # From https://github.com/stalwartlabs/mail-server/blob/main/Dockerfile
 FROM stalwartlabs/mail-server:v0.7.3
 
-COPY config.toml /opt/stalwart-mail/etc/config.toml
+COPY --chmod=664 config.toml /opt/stalwart-mail/etc/config.toml
+COPY --chmod=775 start.sh /start.sh
+
+ENTRYPOINT [ "/start.sh" ]

--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,6 @@ hostname = "mail.%{env:MAIL_DOMAIN}%"
 
 
 [certificate.nextcloud-aio]
-cert = "%{file:/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/%{cfg:lookup.nextcloud-aio.domain}%/%{cfg:lookup.nextcloud-aio.domain}%.crt}%"
+cert = "%{file:/opt/aio-certs/fullchain.crt}%"
 default = true
-private-key = "%{file:/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/%{cfg:lookup.nextcloud-aio.domain}%/%{cfg:lookup.nextcloud-aio.domain}%.key}%"
+cert = "%{file:/opt/aio-certs/privkey.key}%"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+CERT_DIR="/opt/aio-certs"
+CERT_PRIV="$CERT_DIR/privkey.key"
+CERT_PUP="$CERT_DIR/fullchain.crt"
+
+mkdir -p $CERT_DIR
+rm -f "$CERT_PRIV"
+rm -f "$CERT_PUP"
+
+AIO_PRIV="/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/mail.$NC_DOMAIN/mail.$NC_DOMAIN.key"
+AIO_PUB="/caddy/caddy/certificates/acme-v02.api.letsencrypt.org-directory/mail.$NC_DOMAIN/mail.$NC_DOMAIN.crt"
+
+while ! [ -f "$CERT_PRIV" ]; do
+    echo "Waiting for key to get created..."
+    sleep 5
+    [ -f "$AIO_PRIV" ] && cp "$AIO_PRIV" "$CERT_PRIV"
+done
+
+while ! [ -f $CERT_PUP ]; do
+    echo "Waiting for cert to get created..."
+    sleep 5
+    [ -f "$AIO_PUB" ] && cp "$AIO_PUB" "$CERT_PUP"
+done
+
+echo "Stalwart container started"
+
+# Run the normal entrypoint
+/usr/local/bin/entrypoint.sh


### PR DESCRIPTION
- Fix certificate paths #10 and #8
- To use a custom cert, user, you can put a folder "/opt/aio-cert/"
- Updated to V2 because nextcloud comunity container updates are required https://github.com/nextcloud/all-in-one/pull/4556